### PR TITLE
Prevent keep-alive connections if keepAlive option is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ describe('myfun', function() {
 });
 ```
 
+If your testing requires the frequent setup and teardown of the mock server, it may be beneficial to prevent keep-alive connections. The server will always return a `Connection: close` header if constructed with a `keepAlive` option set to `false`.
+
+```
+var couchdb = mockCouch.createServer({ keepAlive: false });
+```
+
 ## Status
 
 Is still in its alpha stage, so its possible that it changes a lot.

--- a/index.js
+++ b/index.js
@@ -8,9 +8,11 @@ var restify = require('restify'),
 
 
 
-function MockCouch () {
+function MockCouch (options) {
   events.EventEmitter.call(this);
-
+  if (!options) {
+    options = {};
+  }
   /** The var 'server' contains the restify server */
   var server = (function() {
     var server = restify.createServer({
@@ -29,6 +31,12 @@ function MockCouch () {
     server.use(restify.bodyParser({ mapParams: false }));
     server.pre(restify.pre.sanitizePath());
     server.use(restify.queryParser());
+    if (options.keepAlive === false) {
+      server.pre(function preventKeepAlive(req, res, next) {
+        res.setHeader('Connection', 'close');
+        next();
+      });
+    }
     return server;
   }());
 
@@ -99,8 +107,8 @@ function MockCouch () {
 util.inherits(MockCouch, events.EventEmitter);
 
 module.exports = {
-  createServer : function() {
+  createServer : function(options) {
     /** Returns a brand new mock couch! */
-    return new MockCouch();
+    return new MockCouch(options);
   }
 };


### PR DESCRIPTION
If a client uses HTTP keep-alive, calling `server.close()` can result in a lengthy delay, based on the keep-alive timeout, which can drastically increase the time to run tests. I've added an options hash to the constructor, with a single option, `keepAlive`, that when set to false will always return a `Connection: close` header, preventing the long lived connection.
