### PR TITLE
Return correct error when deleting a document that does not exist

### DIFF
--- a/lib/delete_doc.js
+++ b/lib/delete_doc.js
@@ -6,17 +6,25 @@ module.exports = function(self) {
    * DELETE method to delete documents
    */
   return function (req, res, next) {
-    var db = self.databases[req.params.db];
-    var rev = req.query.rev || ( req.headers['if-match'] && req.headers['if-match'].replace(/"/g, '') ) || false;
-    var doc = db[req.params.doc] || false;
+    var db = self.databases[req.params.db],
+        rev, doc;
+    if (db) {
+      rev = req.query.rev || ( req.headers['if-match'] && req.headers['if-match'].replace(/"/g, '') ) || false;
+      doc = db[req.params.doc] || false;
 
-    if(!rev || !doc || rev !== doc._rev) {
-      res.send(409, {error:'conflict',reason:'Document update conflict.'});
-      return false;
+      if(!doc) {
+        res.send(404, {error:'not_found',reason:'missing'});
+        return false;
+      }
+      if(!rev || rev !== doc._rev) {
+        res.send(409, {error:'conflict',reason:'Document update conflict.'});
+        return false;
+      }
+
+      delete db[req.params.doc];
+      self.emit('DELETE', { type : 'document', id : req.params.doc });
+      return res.send(200, {ok: true, id: req.params.doc, rev: ''});
     }
-
-    delete db[req.params.doc];
-    self.emit('DELETE', { type : 'document', id : req.params.doc });
-    res.send(200, {ok: true, id: req.params.doc, rev: ''});
+    res.send(404, {error:'not_found',reason:'no_db_file'});
   };
 };


### PR DESCRIPTION
When deleting a document that does not exist, it now returns a 404, not a 409. I also added a 404 response if deleting a document from a database that does not exist.
