### PR TITLE
Return 404 from an _all_docs request if the database was not found.

### DIFF
--- a/lib/all_docs.js
+++ b/lib/all_docs.js
@@ -11,6 +11,12 @@ module.exports = function (self) {
     var original, offset, rows, db;
 
     original = self.databases[req.params.db];
+
+    // return a 404 not found error if the database was not found
+    if (!original) {
+      return res.send(404, { error : 'not_found', reason : 'no_db_file' });
+    }
+
     db = R.cloneDeep(original);
     offset = 0;
 

--- a/test/get_all_docs.spec.js
+++ b/test/get_all_docs.spec.js
@@ -5,7 +5,7 @@ var all_docs_fn = require('../lib/all_docs'),
   mockDB = require('../lib/mockDB');
 
 describe('_all_docs', function () {
-  var mock_mock, get, result, dummy_function, res;
+  var mock_mock, get, statusCode, result, dummy_function, res;
 
   dummy_function = function () {
     return;
@@ -13,6 +13,7 @@ describe('_all_docs', function () {
   /*jslint unparam: true*/
   res = {
     send : function (status, obj) {
+      statusCode = status;
       result = obj;
     },
     setHeader : dummy_function
@@ -50,6 +51,13 @@ describe('_all_docs', function () {
       sequence : { people : 4 }
     };
     get = all_docs_fn(mock_mock);
+  });
+
+  it('should return an error if the database does not exist', function () {
+    get({ route : { method : 'GET' }, params : { db : 'nofound' }, query : { } }, res, dummy_function);
+    expect(statusCode).toBe(404);
+    expect(result.error).toBe('not_found');
+    expect(result.reason).toBe('no_db_file');
   });
 
   it('should get the list of all documents', function () {


### PR DESCRIPTION
Hey,

I stumbled on this after using mock-couchdb to replace calls to a real couchdb server - checking the behaviour with CURL it seems to return the 404 missing database error regardless of whether _all_docs was appended to the database or not. This commit ensures that 404 is always returned.

Thanks, Alex J Burke.