### PR TITLE
Support for linked document in views

### DIFF
--- a/lib/get_view.js
+++ b/lib/get_view.js
@@ -40,7 +40,11 @@ module.exports = function (self) {
         if (!/^_design/.test(doc._id)) {
           var result = { id : doc._id, key : key, value : value };
           if (!useReduce && includeDocs) {
-            result.doc = doc;
+            if ((typeof value._id === 'string') && (value._id !== doc._id)) {
+              result.doc = self.databases[req.params.db][value._id];
+            } else {
+              result.doc = doc;
+            }
           }
           rows.push(result);
         }


### PR DESCRIPTION
If the value for the _id key in the emitted value is different from the
doc._id being evaluated, attach that document as the result.doc instead.

* Fixes #13
* http://wiki.apache.org/couchdb/Introduction_to_CouchDB_views#Linked_documents