### PR TITLE
Complex and partial view-key support

### DIFF
--- a/lib/query_options.js
+++ b/lib/query_options.js
@@ -1,7 +1,8 @@
 /*jslint node: true, indent: 2 , nomen  : true */
 'use strict';
 var R = require('ramda'),
-  isEqual = require('underscore')._.isEqual;
+  isEqual = require('underscore')._.isEqual,
+  keyCompare = require('couch-viewkey-compare');
 
 module.exports = function (req, res, rows) {
   var skip    = (req.query.hasOwnProperty('skip') && parseInt(req.query.skip, 10)) || 0,
@@ -11,8 +12,7 @@ module.exports = function (req, res, rows) {
     key       = req.query.key || false,
     keys      = (req.body && req.body.keys) || (req.query && req.query.keys) || false,
     useDescending = (req.query.hasOwnProperty('descending') && req.query.descending === 'true'),
-    first     = 0,
-    last;
+    tempkey;
 
   // Try to parse startkey
   if (startkey) {
@@ -73,9 +73,12 @@ module.exports = function (req, res, rows) {
     return k;
   }, rows);
 
-  // Reverse the order if descending=true
+  // Reverse the order and the keys if descending=true
   if (useDescending) {
     rows = rows.reverse();
+    tempkey = endkey;
+    endkey = startkey;
+    startkey = tempkey;
   }
 
   // This petition requires to filter using 'keys'
@@ -88,19 +91,40 @@ module.exports = function (req, res, rows) {
     rows = rows.filter(function (row) { return row !== undefined; });
   }
 
-  if (startkey) {
-    first = rows.reduce(function (a, b, i) {
-      return (isEqual(b.key, startkey)) ? i : a;
-    }, 0);
-  }
-  if (endkey) {
-    last = rows.reduce(function (a, b, i) {
-      return (isEqual(b.key, endkey)) ? i : a;
-    }, 0);
+  if (startkey && !endkey) {
+    rows = rows.filter(function (row) {
+      var o = keyCompare(startkey, row.key);
+      if (o === keyCompare.descending) {
+        return false;
+      }
+
+      return true;
+    });
   }
 
-  if (startkey || endkey) {
-    rows = rows.slice(first, last !== undefined ? last + 1 : undefined);
+  if (endkey && !startkey) {
+    rows = rows.filter(function (row) {
+      var o = keyCompare(endkey, row.key);
+      if (o === keyCompare.ascending) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  if (startkey && endkey) {
+    rows = rows.filter(function (row) {
+      var startKeyOrder = keyCompare(startkey, row.key),
+        endKeyOrder = keyCompare(endkey, row.key);
+
+      if ((startKeyOrder === keyCompare.descending) ||
+          (endKeyOrder === keyCompare.ascending)) {
+        return false;
+      }
+
+      return true;
+    });
   }
 
   if (key) {
@@ -112,5 +136,6 @@ module.exports = function (req, res, rows) {
   if (skip > 0 || limit !== false) {
     rows = rows.splice(skip, limit || rows.length - skip);
   }
+
   return rows;
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "ramda": "^0.8.0",
     "restify": "^2.7.0",
-    "underscore": "^1.6.0"
+    "underscore": "^1.6.0",
+    "couch-viewkey-compare": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.4",

--- a/test/views.spec.js
+++ b/test/views.spec.js
@@ -102,7 +102,6 @@ describe('views', function () {
     expect(result.rows[1].id).toBe('miko');
     expect(result.rows[1].key).toBe(null);
     expect(result.rows[7].id).toBe('qball');
-    //console.log(JSON.stringify(result, null, ' '));
   });
   it('should be able to get only one specific key, by disabling reduce', function () {
     get({ route : { method : 'GET' }, params : { db : 'people', doc : 'designer', name : 'someview' }, query : { reduce : 'false', key : '["qball"]' } }, res, dummy_function);


### PR DESCRIPTION
I had a problem where I relied on partial start&end-keys to get view result intervals. The current implementation needed the exact start and/or endkey to be present in the result.

Like a view-result with 
key: "magician"
key: "miko"

and startkey: "me" should only return miko.

To solve this I made a npm package (couch-viewkey-compare, https://github.com/monowerker/couch-viewkey-compare) that implements the CouchDB view-key collation rules in a compare function and rewrote the start&end-key filtering to use it instead.

This compare function could also be used to sort the keys initially, I don't think the string conversion and compare will match CouchDB view-key collation in all cases.

I've found one other npm package that implements CouchDB view-key collation, https://www.npmjs.com/package/pouchdb-collate.