### PR TITLE
Adding support for GET _uuids

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Visit the [Mock Couch website](http://chris-l.github.io/mock-couch/).
     - also, using `_all_docs` with POST to specify the desired keys
  - GET the information of a database
  - GET `_all_dbs`
+ - GET `_uuids`
  - GET views (like `http://localhost:5984/database/_design/myviews/_view/someview/`)
  - PUT one document
  - PUT a database

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function MockCouch(options) {
   this.sequence = {};
 
   (function (server, self) {
-    var all_dbs, all_docs, get_db, get_changes, get_view, get_doc, put_doc;
+    var all_dbs, all_docs, get_db, get_changes, get_view, get_doc, put_doc, get_uuids;
     /**
      * Add the routes
      */
@@ -71,6 +71,10 @@ function MockCouch(options) {
     all_dbs = require('./lib/all_dbs')(self);
     server.get('/_all_dbs', all_dbs);
     server.head('/_all_dbs', all_dbs);
+
+    // GET _uuids
+    get_uuids = require('./lib/uuids')(self);
+    server.get('/_uuids', get_uuids);
 
     // PUT a database
     server.put('/:db', require('./lib/put_db')(self));

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -7,13 +7,13 @@ module.exports = function (self) {
    * GET method used to show a document
    */
   return function (req, res) {
-    var count, ret;
+    var count, ret, i;
 
     count = req.params.count || 1;
 
     ret = [];
 
-    for (var i=0;i<count;++i) {
+    for (i = 0; i < count; i += 1) {
       ret.push(i);
     }
 

--- a/lib/uuids.js
+++ b/lib/uuids.js
@@ -1,0 +1,23 @@
+/*jslint node: true, indent: 2, nomen  : true */
+'use strict';
+var R = require('ramda');
+
+module.exports = function (self) {
+  /**
+   * GET method used to show a document
+   */
+  return function (req, res) {
+    var count, ret;
+
+    count = req.params.count || 1;
+
+    ret = [];
+
+    for (var i=0;i<count;++i) {
+      ret.push(i);
+    }
+
+    res.send(200, ret);
+    return self.emit('GET', { type : 'uuids', count : count });
+  };
+};


### PR DESCRIPTION
I needed support for the _uuids command so have added it here. Instead of generating full UUIDs as per couch, it's just generating integers. For my use case this allows the ID of the generated items to be predicted and therefore checked in the tests.

Updated PR with fixes to lint issues