### PR TITLE
_changes to conform with couchdb implementation

### DIFF
--- a/lib/addDB.js
+++ b/lib/addDB.js
@@ -58,7 +58,7 @@ module.exports = function (name, arr) {
   this.changes[name] = changes;
   Object.defineProperty(this.sequence, name, {
     get : function () {
-      return this.changes[name].length;
+      return this.changes[name].length + 1; //couchdb sequence starts with 1
     }.bind(this)
   });
 

--- a/lib/get_changes.js
+++ b/lib/get_changes.js
@@ -20,7 +20,9 @@ module.exports = function (self) {
 
       return function () {
         R.compose(
-          R.forEach(res.write.bind(res)),
+          R.forEach(function (o) {
+            res.write(o + '\n'); //couchdb changes are split by newline
+          }),
           R.map(stringify),
           R.reduce(function (list, change) {
 

--- a/lib/get_db.js
+++ b/lib/get_db.js
@@ -16,7 +16,7 @@ module.exports = function (self) {
         compact_running: false,
         disk_format_version: 5,
         doc_del_count: 0, // not supported yet
-        instance_start_time: 0,
+        instance_start_time: Date.now(),
         purge_seq: 0,
         update_seq: 0
       });

--- a/test/get_changes.spec.js
+++ b/test/get_changes.spec.js
@@ -44,10 +44,10 @@ describe('get_changes', function () {
     save_doc({ route : { method : 'POST' }, params : { db : 'people', doc : 'player2' }, body : { name : 'sanae', lastname : 'kochiya' } }, res, dummy_function);
     expect(!!mock_mock.databases.people.player2).toBe(true);
     expect(mock_mock.databases.people.player2.name).toBe('sanae');
-    expect(mock_mock.sequence.people).toEqual(2);
+    expect(mock_mock.sequence.people).toEqual(3);
     var change = mock_mock.changes.people.pop();
     expect(change.id).toEqual('player2');
-    expect(change.seq).toEqual(1);
+    expect(change.seq).toEqual(2);
     expect(change.doc._id).toEqual('player2');
     mock_mock.changes.people.push(change);
   });
@@ -56,11 +56,12 @@ describe('get_changes', function () {
     save_doc({ route : { method : 'POST' }, params : { db : 'people', doc : '_local/test' }, body : { test_local : 'value' } }, res, dummy_function);
     // no changes should be added
     expect(mock_mock.changes.people.length).toEqual(1);
-    expect(mock_mock.sequence.people).toEqual(1);
+    expect(mock_mock.sequence.people).toEqual(2);
   });
 
   it('should get the changes since revision 0', function (done) {
     res.write = function (str) {
+      expect(str[str.length - 1]).toEqual('\n');
       var chunk = JSON.parse(str);
       expect(chunk.id).toEqual('miko');
       expect(chunk.seq).toEqual(0);


### PR DESCRIPTION
Some libraries like [follow](https://github.com/iriscouch/follow) currently fail with mock-couch responses
This fixes follow: 
* Set server start time to Date.now()(zero value fails if library doesn't check against explicit value)
* Real couchdb sequences start with 1
* Couchdb splits continues changes with newline when sending changes to client