### PR TITLE
Fixes issue when calling addDB multiple times.

### DIFF
--- a/lib/addDB.js
+++ b/lib/addDB.js
@@ -56,11 +56,13 @@ module.exports = function (name, arr) {
 
   this.databases[name] = mockDB(database);
   this.changes[name] = changes;
-  Object.defineProperty(this.sequence, name, {
-    get : function () {
-      return this.changes[name].length + 1; //couchdb sequence starts with 1
-    }.bind(this)
-  });
+  if (!this.sequence.hasOwnProperty(name)) {
+    Object.defineProperty(this.sequence, name, {
+      get : function () {
+        return this.changes[name].length + 1; //couchdb sequence starts with 1
+      }.bind(this)
+    });
+  }
 
   return this.databases[name];
 };


### PR DESCRIPTION
Fix required when calling addDB multiple times.  If called multiple times, with add db, then delete db: without this check, the property will throw an exception for being redefined.