### PR TITLE
updated spec and get_view to allow for views inserted as strings to r…

### DIFF
--- a/lib/get_view.js
+++ b/lib/get_view.js
@@ -1,4 +1,4 @@
-/*jslint node: true, indent: 2, nomen  : true */
+/*jslint node: true, indent: 2, nomen  : true, evil:true*/
 'use strict';
 var R = require('ramda'),
   doFilter = require('./query_options'),
@@ -25,6 +25,9 @@ module.exports = function (self) {
     db = formatDB(self.databases[req.params.db]);
 
     view = self.databases[req.params.db]['_design/' + req.params.doc].views[req.params.name];
+    if (typeof (view.map) === "string") {
+      eval('view.map =' + view.map.replace(/(?:\r\n|\r|\n)/g, ''));
+    }
 
     // Create flags
     useReduce     = (view.hasOwnProperty('reduce') && (!req.query.hasOwnProperty('reduce') || req.query.reduce !== 'false'));

--- a/test/views.spec.js
+++ b/test/views.spec.js
@@ -93,6 +93,9 @@ describe('views', function () {
                   emit([doc.trainer, doc.friends.length], null);
                 }
               }
+            },
+            stringView : {
+              map: "function(doc) {\nif(doc.type === 'player')\n  emit(doc.name.toLowerCase(), null);\n}"
             }
           },
           _rev : '88888'
@@ -208,5 +211,10 @@ describe('views', function () {
     save_doc({ route : { method : 'POST' }, params : { db : 'people', designdoc : 'test' }, query : {}, body : { views : { all : { map : "function(doc) { if (doc.money > 30) { emit(doc._id, doc.money); } }" } } } }, res, dummy_function);
     get({ route : { method : 'GET' }, query : {}, params : { db : 'people', doc : 'test', name : 'all' }  }, res, dummy_function);
     expect(result.rows.length).toBe(2);
+  });
+
+  it('should emit documents from views inserted as a string', function () {
+    get({ route : { method : 'GET' }, params : { db : 'people', doc : 'designer', name : 'stringView' }, query : {} }, res, dummy_function);
+    expect(result.rows.length).toBe(4);
   });
 });


### PR DESCRIPTION
A popular module couchviews is used to dump the views from an existing couch database and save them as a json file, this is then reimported using the same module into a new couch database (in this case mock-couch). This works on a real instance of couchdb, but on mock couch because it was inserted from a json string, the map function is unable to run. I've updated the spec and the code to allow for integration with this module