### PR TITLE
[#47] View collation does not sort keys correctly

### DIFF
--- a/lib/query_options.js
+++ b/lib/query_options.js
@@ -65,13 +65,9 @@ module.exports = function (req, res, rows, isAllDocs) {
   }
 
   // Sort rows
-  rows = R.sortBy(function (row) {
-    var k = row.key || '';
-    if (typeof k === 'object' && k !== null && !Array.isArray(k)) {
-      k = JSON.stringify(k);
-    }
-    return k;
-  }, rows);
+  rows.sort(function (a, b) {
+    return keyCompare(a.key, b.key);
+  });
 
   // Reverse the order and the keys if descending=true
   if (useDescending) {

--- a/lib/query_options.js
+++ b/lib/query_options.js
@@ -67,7 +67,7 @@ module.exports = function (req, res, rows, isAllDocs) {
   // Sort rows
   rows = R.sortBy(function (row) {
     var k = row.key || '';
-    if (typeof k === 'object' && k !== null) {
+    if (typeof k === 'object' && k !== null && !Array.isArray(k)) {
       k = JSON.stringify(k);
     }
     return k;


### PR DESCRIPTION
The function provided to R.sortBy causes a simple equality check to be performed on keys (a < b).  The problem I discovered is that arrays are caught in the `if (typeof k === 'object' && k !== null)` check. This results in the comparison being done as a string instead of an array, which produces incorrect ordering.

It looks like Couch view collation applies key ordering implicitly (should not only be done if user provides starkey, endkey, descending, etc.). Therefore, it seems best to use keyCompare here in every case. This fixes the issue I was seeing with arrays, and presumably will fix any possible issues with other key type comparisons.

I would appreciate any feedback!
