### PR TITLE
Add simple partition support (get from partition view). Allow _delete…

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ function MockCouch(server, options) {
     server.get('/:db/_design/:doc/_view/:name', get_view);
     server.post('/:db/_design/:doc/_view/:name', get_view);
 
+    // GET from a certain partition view
+    server.get('/:db/_partition/:partition/_design/:doc/_view/:name', get_view);
+
     // GET and HEAD a certain document or _design document
     get_doc = require('./lib/get_doc')(self);
     server.get('/:db/_design/:designdoc/', get_doc);

--- a/lib/bulk_docs.js
+++ b/lib/bulk_docs.js
@@ -32,7 +32,7 @@ module.exports = function (self) {
       // Save the doc
       db[id] = doc;
 
-      return {id: id, rev: doc._rev};
+      return {ok: true, id: id, rev: doc._rev};
     }
 
     if (!req.body || !req.body.docs) {
@@ -42,6 +42,12 @@ module.exports = function (self) {
 
 
     docs = req.body.docs.map(function (doc) {
+
+      // Is a document to delete
+      if (doc._deleted && db[doc._id]._rev === doc._rev) {
+        delete db[doc._id];
+        return {ok: true, id: doc._id, rev: doc._rev};
+      }
 
       // is a new document without id
       if (!doc._id) {

--- a/lib/get_uuids.js
+++ b/lib/get_uuids.js
@@ -9,7 +9,7 @@ module.exports = function (self) {
   return function (req, res) {
     var count, ret, i, seqPrefix;
 
-    count = req.query.count || 1;
+    count = (req.query && req.query.count) || 1;
 
     ret = [];
 

--- a/lib/get_uuids.js
+++ b/lib/get_uuids.js
@@ -1,5 +1,6 @@
 /*jslint node: true, indent: 2, nomen  : true */
 'use strict';
+var createMD5 = require('./createMD5');
 
 module.exports = function (self) {
   /**
@@ -8,11 +9,11 @@ module.exports = function (self) {
   return function (req, res) {
     var count, ret, i, seqPrefix;
 
-    count = req.params.count || 1;
+    count = req.query.count || 1;
 
     ret = [];
 
-    seqPrefix = self.seqPrefix || '4e17c12963f4bee0e6ec90da54';
+    seqPrefix = self.seqPrefix || createMD5();
     for (i = 0; i < count; i += 1) {
       ret.push(seqPrefix + ('000000' + i).substr(-6, 6));
     }

--- a/lib/get_view.js
+++ b/lib/get_view.js
@@ -24,7 +24,15 @@ module.exports = function (self) {
 
     db = formatDB(self.databases[req.params.db]);
 
-    view = self.databases[req.params.db]['_design/' + req.params.doc].views[req.params.name];
+    try {
+      view = self.databases[req.params.db]['_design/' + req.params.doc].views[req.params.name];
+    } catch (e) {
+      res.send(404, {
+        error: 'not_found',
+        reason: 'missing'
+      });
+      return false;
+    }
     req.query = req.query || {};
 
     // Create flags
@@ -47,7 +55,9 @@ module.exports = function (self) {
               result.doc = doc;
             }
           }
-          rows.push(result);
+          if (!req.params.partition || result.id.startsWith(req.params.partition + ':')) {
+            rows.push(result);
+          }
         }
       };
       view.map(local);
@@ -180,4 +190,3 @@ module.exports = function (self) {
     next();
   };
 };
-

--- a/test/get_uuids.spec.js
+++ b/test/get_uuids.spec.js
@@ -36,23 +36,22 @@ describe('get_uuids', function () {
   });
 
   it('should get a single uuid', function () {
-    get({ params : {} }, res, dummy_function);
+    get({ query : {} }, res, dummy_function);
     expect(result.uuids.length).toBe(1);
-    expect(result.uuids[0]).toEqual("4e17c12963f4bee0e6ec90da54000000");
     expect(statusCode).toBe(200);
   });
 
   it('should get multiple uuids', function () {
-    get({ params : {"count": 3} }, res, dummy_function);
+    get({ query : {"count": 3} }, res, dummy_function);
     expect(result.uuids.length).toBe(3);
-    expect(result.uuids[0]).toEqual("4e17c12963f4bee0e6ec90da54000000");
-    expect(result.uuids[1]).toEqual("4e17c12963f4bee0e6ec90da54000001");
-    expect(result.uuids[2]).toEqual("4e17c12963f4bee0e6ec90da54000002");
+    expect(result.uuids[0].slice(-6)).toEqual("000000");
+    expect(result.uuids[1].slice(-6)).toEqual("000001");
+    expect(result.uuids[2].slice(-6)).toEqual("000002");
     expect(statusCode).toBe(200);
   });
 
   it('should allow a custom prefix', function () {
-    custom_get({ params : {} }, res, dummy_function);
+    custom_get({ query : {} }, res, dummy_function);
     expect(result.uuids.length).toBe(1);
     expect(result.uuids[0]).toEqual("4e17c12963f4bee0e6ec90da55000000");
     expect(statusCode).toBe(200);


### PR DESCRIPTION
…d for bulk_docs. Fix a flaw in get_uuids.

Just fixing up what I needed to try and use this for unit testing.
- really simple partition view support
  `http://localhost:5984/mydatabase/_partition/mypartition/_design/myviews/_view/someview/`
- added support for `_deleted` in the _bulk_docs POST
- Also include `ok: true` for each bulk doc added/deleted since that is what my real couch db does
    https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-docs
- Fix get_view that was crashing when trying to retrieve docs from a nonexistent view (now returns 404 - same error as real couch db)
- Fixed get_uuids to return multiple uuids when requested. It was looking for `req.params.count` but it should have been `req.query.count`
    https://docs.couchdb.org/en/stable/api/server/common.html#uuids
- Also get_uuids was returning duplicate uuids so I tweaked that as well.